### PR TITLE
Fix channel mismatch in output monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,8 @@
 
 - Xcode 12+
 - macOS 11+
+- When monitoring output devices, make sure the project has the `com.apple.security.device.audio-output` entitlement enabled.
+- Use `activeOutputChannelCount` from `ObservableAudioDevice` when configuring
+  output monitoring to match the device's current stream channels.
 
 ![Screenshot](images/Screenshot.png "a title")

--- a/SimplyCoreAudioDemo/Extensions/ObservableAudioDevice+Extensions.swift
+++ b/SimplyCoreAudioDemo/Extensions/ObservableAudioDevice+Extensions.swift
@@ -13,7 +13,7 @@ extension ObservableAudioDevice {
 
     var prettyChannelsDescription: String {
         let inChannelDescription = "\(inputChannelCount) in\(inputChannelCount != 1 ? "s" : "")"
-        let outChannelDescription = "\(outputChannelCount) out\(outputChannelCount != 1 ? "s" : "")"
+        let outChannelDescription = "\(activeOutputChannelCount) out\(activeOutputChannelCount != 1 ? "s" : "")"
 
         return "\(inChannelDescription) / \(outChannelDescription)"
     }

--- a/SimplyCoreAudioDemo/Observables/ObservableAudioDevice.swift
+++ b/SimplyCoreAudioDemo/Observables/ObservableAudioDevice.swift
@@ -19,6 +19,10 @@ class ObservableAudioDevice: ObservableObject, Identifiable {
     @Published var clockSourceName: String
     @Published var inputChannelCount: UInt32
     @Published var outputChannelCount: UInt32
+    // Number of channels currently active in the device's output stream.
+    // This value may differ from `outputChannelCount` when the device
+    // is configured for mono output.
+    @Published var activeOutputChannelCount: UInt32
 
     @Published var isInputOnlyDevice: Bool
     @Published var isOutputOnlyDevice: Bool
@@ -60,6 +64,8 @@ class ObservableAudioDevice: ObservableObject, Identifiable {
 
         inputChannelCount = device.channels(scope: .input)
         outputChannelCount = device.channels(scope: .output)
+        // Query the current stream format to account for mono devices.
+        activeOutputChannelCount = device.streamFormat(scope: .output)?.mChannelsPerFrame ?? outputChannelCount
 
         nominalSampleRates = device.nominalSampleRates ?? []
         clockSourceIDs = device.clockSourceIDs ?? []
@@ -74,6 +80,13 @@ class ObservableAudioDevice: ObservableObject, Identifiable {
 
     func clockSourceName(for id: UInt32) -> String {
         device.clockSourceName(clockSourceID: id) ?? "Default"
+    }
+
+    /// Refresh channel information from the underlying device.
+    func refreshChannels() {
+        inputChannelCount = device.channels(scope: .input)
+        outputChannelCount = device.channels(scope: .output)
+        activeOutputChannelCount = device.streamFormat(scope: .output)?.mChannelsPerFrame ?? outputChannelCount
     }
 }
 

--- a/SimplyCoreAudioDemo/Observables/ObservableSCA.swift
+++ b/SimplyCoreAudioDemo/Observables/ObservableSCA.swift
@@ -43,6 +43,7 @@ private extension ObservableSCA {
         if let defaultInputDevice = simply.defaultInputDevice {
             for device in devices {
                 device.isDefaultInputDevice = device.id == defaultInputDevice.id
+                device.refreshChannels()
             }
         }
     }
@@ -51,6 +52,7 @@ private extension ObservableSCA {
         if let defaultOutputDevice = simply.defaultOutputDevice {
             for device in devices {
                 device.isDefaultOutputDevice = device.id == defaultOutputDevice.id
+                device.refreshChannels()
             }
         }
     }
@@ -59,6 +61,7 @@ private extension ObservableSCA {
         if let defaultSystemDevice = simply.defaultSystemOutputDevice {
             for device in devices {
                 device.isDefaultSystemOutputDevice = device.id == defaultSystemDevice.id
+                device.refreshChannels()
             }
         }
     }
@@ -77,6 +80,10 @@ private extension ObservableSCA {
                         self.deviceForDevice.removeValue(forKey: device)
                     }
                 }
+
+                for observable in self.deviceForDevice.values {
+                    observable.refreshChannels()
+                }
             },
 
             notificationCenter.addObserver(forName: .defaultInputDeviceChanged, object: nil, queue: .main) { (_) in
@@ -85,10 +92,16 @@ private extension ObservableSCA {
 
             notificationCenter.addObserver(forName: .defaultOutputDeviceChanged, object: nil, queue: .main) { (_) in
                 self.updateDefaultOutputDevice()
+                for observable in self.deviceForDevice.values {
+                    observable.refreshChannels()
+                }
             },
 
             notificationCenter.addObserver(forName: .defaultSystemOutputDeviceChanged, object: nil, queue: .main) { (_) in
                 self.updateDefaultSystemDevice()
+                for observable in self.deviceForDevice.values {
+                    observable.refreshChannels()
+                }
             },
 
             notificationCenter.addObserver(forName: .deviceNominalSampleRateDidChange, object: nil, queue: .main) { (notification) in
@@ -96,6 +109,7 @@ private extension ObservableSCA {
                     if let nominalSampleRate = _device.nominalSampleRate {
                         device.nominalSampleRate = nominalSampleRate
                     }
+                    device.refreshChannels()
                 }
             },
 
@@ -104,6 +118,7 @@ private extension ObservableSCA {
                     if let clockSourceName = _device.clockSourceName {
                         device.clockSourceName = clockSourceName
                     }
+                    device.refreshChannels()
                 }
             },
         ])

--- a/SimplyCoreAudioDemo/SimplyCoreAudioDemo.entitlements
+++ b/SimplyCoreAudioDemo/SimplyCoreAudioDemo.entitlements
@@ -4,9 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
-	<key>com.apple.security.device.usb</key>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+        <key>com.apple.security.device.audio-output</key>
+        <true/>
+        <key>com.apple.security.device.usb</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>


### PR DESCRIPTION
## Summary
- track active output channels from the device stream
- refresh channels whenever device or defaults change
- show active output channel count in the UI
- note how to use the count for monitoring

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_685082de153c8332bb59d17b3f0bf670